### PR TITLE
added docker compose for easier set up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+FROM nvidia/cuda:12.3.0-devel-ubuntu22.04
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git wget unzip bzip2 sudo build-essential ca-certificates openssh-server vim ffmpeg libsm6 libxext6 python3-opencv gcc-11 g++-11 cmake
+
+# conda
+ENV PATH /opt/conda/bin:$PATH 
+RUN wget --quiet \
+    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    /bin/bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm -rf /tmp/*
+
+# Create the user
+RUN addgroup --gid $GROUP_ID user
+RUN useradd --create-home -s /bin/bash --uid $USER_ID --gid $GROUP_ID docker
+RUN adduser docker sudo
+RUN echo "docker ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER docker
+
+# Setup hierarchical_3d_gaussians
+RUN /opt/conda/bin/python -m ensurepip
+RUN /opt/conda/bin/python -m pip install torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
+RUN /opt/conda/bin/python -m pip install plyfile tqdm joblib exif scikit-learn timm==0.4.5 opencv-python==4.9.0.80 gradio_imageslider gradio==4.29.0 matplotlib
+
+# Install COLMAP dependencies
+RUN sudo apt-get install -y --no-install-recommends \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
+    libboost-graph-dev \
+    libboost-system-dev \
+    libboost-test-dev \
+    libeigen3-dev \
+    libsuitesparse-dev \
+    libfreeimage-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libglew-dev \
+    qtbase5-dev \
+    libqt5opengl5-dev \
+    libcgal-dev \
+    libatlas-base-dev \
+    libsuitesparse-dev \
+    libmetis-dev \
+    libflann-dev \
+    libsqlite3-dev \
+    libceres-dev
+
+# Clone COLMAP repository
+RUN sudo git clone https://github.com/colmap/colmap
+
+RUN cd /colmap && \
+    sudo mkdir build && \
+    cd build && \
+    sudo cmake -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_CUDA_ARCHITECTURES="75;80;86;87;90" .. && \
+    sudo make -j8 && \
+    sudo make install
+
+WORKDIR /host
+
+# Copy the entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+
+# Make the entrypoint script executable
+RUN sudo chmod +x /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+    hierarchical_3d_gaussians:
+        container_name: hierarchical_3d_gaussians
+        build:
+            context: .
+            dockerfile: Dockerfile
+        stdin_open: true
+        tty: true
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          count: all
+                          capabilities:
+                              - gpu
+        volumes:
+            - ${PWD}:/host
+            - ./data/:/data
+        ports:
+            - "6009:6009"
+        ipc: host
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
+        entrypoint: ["/entrypoint.sh"]
+        command: ["bash"]
+        networks:
+            - main
+
+networks:
+    main:
+        driver: bridge

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+pip install -r /host/requirements.txt
+
+echo "Container is running"
+
+exec "$@"


### PR DESCRIPTION
Made a docker compose environment so users or contributors can more easily get H3DGS running on their own machines. It isn't the most ideal docker configuration, but the pay off is definitely worth it since all you need to run is `docker-compose up` and the environment will be running in a docker container. I tested this by using my own dataset and shelling into the container with `docker exec -it hierarchical_3d_gaussians` and successfully ran these commands on my own data: 

`python ./preprocess/generate_colmap.py --project_dir data/my_data`

`python ./preprocess/generate_chunks.py --project_dir data/my_data`

`python ./preprocess/generate_depth.py --project_dir data/my_data`

`python ./scripts/full_train.py --project_dir data/my_data` 